### PR TITLE
Sqlite3 gem needed in test env to run specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in hydra-batch-edit.gemspec
 gemspec
+
+group :development, :test do
+  gem 'sqlite3'
+end


### PR DESCRIPTION
Otherwise:

```
mjg@moby:~/workspace/hydra-batch-edit-PSU (master[2.0.0@hydra-batch-edit]⚡)$ bundle exec rake clean spec
Removing sample rails app
Generating rails app
Copying gemfile
Copying generator
Bundle install
running generator
/home/mjg/.rvm/gems/ruby-2.0.0-p0@global/gems/bundler-1.3.4/lib/bundler/rubygems_integration.rb:214:in `block in replace_gem': Please install the sqlite3 adapter: `gem install activerecord-sqlite3-adapter` (sqlite3 is not part of the bundle. Add it to Gemfile.) (LoadError)
...
```
