### PR TITLE
Adding an after hook, afterUpdateCheckbox

### DIFF
--- a/app/assets/javascripts/batch_edit.js.coffee
+++ b/app/assets/javascripts/batch_edit.js.coffee
@@ -57,6 +57,9 @@ $.fn.batchEdit = (args) ->
     update_state_for(checkbox, checked, label, form)
     form.append(label)
 
+    #allow the user to bind some actions to the check box after it has been updated
+    args.afterCheckboxUpdate(checkbox)  if args.afterCheckboxUpdate
+
     # TODO make this into a new method
     checkbox.bind 'click', ->
       cb = $(this)


### PR DESCRIPTION
afterUpdateCheckbox will be called after the blacklight button is converted to a check box to allow for additional actions to be bound to the checkboxes.
