### PR TITLE
adding blacklight_solr since the lates blacklight requires it

### DIFF
--- a/lib/hydra/batch_edit/search_service.rb
+++ b/lib/hydra/batch_edit/search_service.rb
@@ -8,6 +8,10 @@ module Hydra
         @session = session
         @user_key = user_key
         self.class.copy_blacklight_config_from(::CatalogController)
+       end
+
+      def blacklight_solr
+        Blacklight.solr
       end
 
       solr_search_params_logic << :apply_gated_search


### PR DESCRIPTION
The all request errored out due to missing blacklight_solr variable.  This just adds the definition so we can use the solr_query.
This change is needed for blacklight 4.2
