### PR TITLE
Add missing application.js reference

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -43,6 +43,7 @@ In your Gemfile, add
 # Add javascript to app/assets/javascripts/application.js
 <pre>
   //= require batch_edit
+  //= require hydra/batch_select
 </pre>
 # Add css to app/assets/stylesheets/application.css
 <pre>


### PR DESCRIPTION
The documentation is missing a step from the installation guide for adding the hydra collections batch_select JS file to application.js
