### PR TITLE
Remove dependency on Hydra::Collections

### DIFF
--- a/app/controllers/concerns/hydra/batch_edit_behavior.rb
+++ b/app/controllers/concerns/hydra/batch_edit_behavior.rb
@@ -3,7 +3,7 @@ module Hydra
     extend ActiveSupport::Concern
     
     included do
-      include Hydra::Collections::AcceptsBatches
+      include CurationConcerns::Collections::AcceptsBatches
 
       before_filter :filter_docs_with_access!, :only=>[:edit, :update, :destroy_collection]
       before_filter :check_for_empty!, :only=>[:edit, :update, :destroy_collection]

--- a/hydra-batch-edit.gemspec
+++ b/hydra-batch-edit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'APACHE2'
 
   gem.add_dependency 'blacklight'
-  gem.add_dependency 'hydra-collections'
+  gem.add_dependency 'curation_concerns'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rails'


### PR DESCRIPTION
Removes Hydra::Collections dependency in favor of CurationConcerns. The only method it appears to need is `filter_docs_with_access`, which could be provided independently, or in a different way.